### PR TITLE
Update and reorganize projects

### DIFF
--- a/plugins/filestorage/pom.xml
+++ b/plugins/filestorage/pom.xml
@@ -9,17 +9,17 @@
 
 	<name>filestorage</name>
 	<url>https://dicoogle.com</url>
-    
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+	
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
 
-    <parent>
-        <groupId>pt.ua.ieeta</groupId>
-        <artifactId>dicoogle-plugins</artifactId>
-        <version>3.4.1</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
+	<parent>
+		<groupId>pt.ua.ieeta</groupId>
+		<artifactId>dicoogle-plugins</artifactId>
+		<version>3.4.1</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 
 	<build>
 		<plugins>

--- a/plugins/filestorage/pom.xml
+++ b/plugins/filestorage/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>filestorage</name>
-	<url>http://maven.apache.org</url>
+	<url>https://dicoogle.com</url>
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -21,75 +21,22 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-	<repositories>
-
-		<repository>
-			<id>dicoogle-public</id>
-			<url>https://dev.bmd-software.com/nexus/content/repositories/dicoogle-public</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-
-	</repositories>
-
-
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
 			</plugin>
 
 			<plugin>
 				<groupId>com.mycila</groupId>
 				<artifactId>license-maven-plugin</artifactId>
-				<version>2.4</version>
-				<configuration>
-					<header>../../short-license.txt</header>
-					<includes>
-						<include>**/*.java</include>
-					</includes>
-					<excludes>
-						<exclude>**/package-info.java</exclude>
-					</excludes>
-
-				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
-
-			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<configuration>
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
-					<archive>
-
-					</archive>
-				</configuration>
-				<executions>
-					<execution>
-						<id>make-assembly</id>
-						<phase>package</phase>
-						<goals>
-							<goal>single</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-
 		</plugins>
 	</build>
 
@@ -97,13 +44,13 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>1.7.21</version>
+			<version>1.7.36</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -116,14 +63,11 @@
 			<groupId>pt.ua.ieeta</groupId>
 			<artifactId>dicoogle-sdk</artifactId>
 			<version>${dicoogle-sdk.version}</version>
-
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>2.4</version>
 		</dependency>
-
-
 	</dependencies>
 </project>

--- a/plugins/lucene/pom.xml
+++ b/plugins/lucene/pom.xml
@@ -15,95 +15,32 @@
     </parent>
 
 	<name>lucene</name>
-	<url>https://www.dicoogle.com</url>
-	<repositories>
-		<repository>
-			<id>dcm4che</id>
-			<url>https://www.dcm4che.org/maven2/</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>dicoogle-public</id>
-			<url>https://dev.bmd-software.com/nexus/content/repositories/dicoogle-public</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
+	<url>https://dicoogle.com</url>
+
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
-
-			<plugin>
-				<groupId>com.mycila</groupId>
-				<artifactId>license-maven-plugin</artifactId>
-				<version>2.4</version>
-				<configuration>
-					<header>../../short-license.txt</header>
-					<includes>
-						<include>**/*.java</include>
-					</includes>
-					<excludes>
-						<exclude>**/package-info.java</exclude>
-					</excludes>
-
-				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.3</version>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<filters>
-								<filter>
-									<artifact>*:*</artifact>
-									<excludes>
-										<exclude>**/*.SF</exclude>
-										<exclude>**/*.DSA</exclude>
-										<exclude>**/*.RSA</exclude>
-									</excludes>
-								</filter>
-							</filters>
-							<minimizeJar>false</minimizeJar>
-						</configuration>
-					</execution>
-				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>com.mycila</groupId>
+				<artifactId>license-maven-plugin</artifactId>
 			</plugin>
 		</plugins>
 	</build>
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -138,7 +75,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.12</version>
+			<version>1.7.36</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/plugins/lucene/pom.xml
+++ b/plugins/lucene/pom.xml
@@ -7,12 +7,12 @@
 	<version>3.4.1</version>
 	<packaging>jar</packaging>
 
-    <parent>
-        <groupId>pt.ua.ieeta</groupId>
-        <artifactId>dicoogle-plugins</artifactId>
-        <version>3.4.1</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
+	<parent>
+		<groupId>pt.ua.ieeta</groupId>
+		<artifactId>dicoogle-plugins</artifactId>
+		<version>3.4.1</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 
 	<name>lucene</name>
 	<url>https://dicoogle.com</url>

--- a/pom.xml
+++ b/pom.xml
@@ -1,27 +1,97 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>pt.ua.ieeta</groupId>
-  <artifactId>dicoogle-plugins</artifactId>
-  <version>3.4.1</version>
-  <packaging>pom</packaging>
-  <name>dicoogle-plugins</name>
-  <properties>
-        <dicoogle-sdk.version>3.3.3</dicoogle-sdk.version>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>pt.ua.ieeta</groupId>
+    <artifactId>dicoogle-plugins</artifactId>
+    <version>3.4.1</version>
+    <packaging>pom</packaging>
+    <name>dicoogle-plugins</name>
+    <url>https://dicoogle.com</url>
+
+    <properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <dicoogle-sdk.version>3.4.1</dicoogle-sdk.version>
     </properties>
+
+	<repositories>
+		<repository>
+			<id>dcm4che</id>
+			<url>https://www.dcm4che.org/maven2/</url>
+		</repository>
+		<repository>
+			<id>dicoogle-public</id>
+			<url>https://dev.bmd-software.com/nexus/content/repositories/dicoogle-public</url>
+		</repository>
+	</repositories>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.14.0</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <release>8</release>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>**/*.SF</exclude>
+                                        <exclude>**/*.DSA</exclude>
+                                        <exclude>**/*.RSA</exclude>
+                                        <exclude>**/module-info.class</exclude>
+                                        <exclude>**/module-info.java</exclude>
+                                        <exclude>META-INF/versions/**/*.class</exclude>
+                                        <exclude>META-INF/DEPENDENCIES</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <minimizeJar>false</minimizeJar>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>2.9</version>
+                <configuration>
+                    <header>short-license.txt</header>
+                    <includes>
+                        <include>**/*.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>tools/**</exclude>
+                        <exclude>**/package-info.java</exclude>
+                    </excludes>
+                </configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+            </plugin>            
         </plugins>
     </build>
+
     <modules>
         <module>plugins/filestorage</module>
         <module>plugins/lucene</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>pt.ua.ieeta</groupId>
-    <artifactId>dicoogle-plugins</artifactId>
-    <version>3.4.1</version>
-    <packaging>pom</packaging>
-    <name>dicoogle-plugins</name>
-    <url>https://dicoogle.com</url>
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>pt.ua.ieeta</groupId>
+	<artifactId>dicoogle-plugins</artifactId>
+	<version>3.4.1</version>
+	<packaging>pom</packaging>
+	<name>dicoogle-plugins</name>
+	<url>https://dicoogle.com</url>
 
-    <properties>
+	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dicoogle-sdk.version>3.4.1</dicoogle-sdk.version>
-    </properties>
+		<dicoogle-sdk.version>3.4.1</dicoogle-sdk.version>
+	</properties>
 
 	<repositories>
 		<repository>
@@ -25,62 +25,62 @@
 		</repository>
 	</repositories>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.14.0</version>
-                <configuration>
-                    <release>8</release>
-                </configuration>
-            </plugin>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.14.0</version>
+				<configuration>
+					<release>8</release>
+				</configuration>
+			</plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.0</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>**/*.SF</exclude>
-                                        <exclude>**/*.DSA</exclude>
-                                        <exclude>**/*.RSA</exclude>
-                                        <exclude>**/module-info.class</exclude>
-                                        <exclude>**/module-info.java</exclude>
-                                        <exclude>META-INF/versions/**/*.class</exclude>
-                                        <exclude>META-INF/DEPENDENCIES</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
-                            <minimizeJar>false</minimizeJar>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.6.0</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>**/*.SF</exclude>
+										<exclude>**/*.DSA</exclude>
+										<exclude>**/*.RSA</exclude>
+										<exclude>**/module-info.class</exclude>
+										<exclude>**/module-info.java</exclude>
+										<exclude>META-INF/versions/**/*.class</exclude>
+										<exclude>META-INF/DEPENDENCIES</exclude>
+									</excludes>
+								</filter>
+							</filters>
+							<minimizeJar>false</minimizeJar>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 
-            <plugin>
-                <groupId>com.mycila</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>2.9</version>
-                <configuration>
-                    <header>short-license.txt</header>
-                    <includes>
-                        <include>**/*.java</include>
-                    </includes>
-                    <excludes>
-                        <exclude>tools/**</exclude>
-                        <exclude>**/package-info.java</exclude>
-                    </excludes>
-                </configuration>
+			<plugin>
+				<groupId>com.mycila</groupId>
+				<artifactId>license-maven-plugin</artifactId>
+				<version>2.9</version>
+				<configuration>
+					<header>short-license.txt</header>
+					<includes>
+						<include>**/*.java</include>
+					</includes>
+					<excludes>
+						<exclude>tools/**</exclude>
+						<exclude>**/package-info.java</exclude>
+					</excludes>
+				</configuration>
 				<executions>
 					<execution>
 						<goals>
@@ -88,12 +88,12 @@
 						</goals>
 					</execution>
 				</executions>
-            </plugin>            
-        </plugins>
-    </build>
+			</plugin>
+		</plugins>
+	</build>
 
-    <modules>
-        <module>plugins/filestorage</module>
-        <module>plugins/lucene</module>
-    </modules>
+	<modules>
+		<module>plugins/filestorage</module>
+		<module>plugins/lucene</module>
+	</modules>
 </project>

--- a/scripts/installers/general/generateSourcesAndBinariesIndependent.sh
+++ b/scripts/installers/general/generateSourcesAndBinariesIndependent.sh
@@ -73,9 +73,9 @@ echo "#######################"
 #Binaries
 cp dicoogle/dicoogle/target/dicoogle.jar $DICOOGLE_BIN/
 cp dicoogle/README.md $DICOOGLE_BIN/
-cp dicoogle-pvt/plugins/lucene/target/lucene-$VERSION.jar $DICOOGLE_BIN/Plugins
-cp dicoogle-pvt/plugins/filestorage/target/filestorage-$VERSION-jar-with-dependencies.jar $DICOOGLE_BIN/Plugins
-cp ../bin/* $DICOOGLE_BIN/
+cp "dicoogle-pvt/plugins/lucene/target/lucene-$VERSION.jar" "$DICOOGLE_BIN/Plugins/"
+cp "dicoogle-pvt/plugins/filestorage/target/filestorage-$VERSION.jar" "$DICOOGLE_BIN/Plugins/"
+cp ../bin/* "$DICOOGLE_BIN/"
 
 echo "Zipping..."
 
@@ -84,7 +84,7 @@ zip -9 -r $DICOOGLE_BIN.zip $DICOOGLE_BIN
 echo "Zipping...done"
 #Sources
 
-echo "Cleaning ..."
+#echo "Cleaning ..."
 
 #rm -rf dicoogle-pvt
 #rm -rf dicoogle


### PR DESCRIPTION
### Summary

- update maven-compile-plugin
- update maven-shade-plugin
- update maven-license-plugin
- set property `dicoogle-sdk-version` correctly
- move common project elements to root
- update junit to 4.43.2
- patch update slf4j
- shade filestorage plugin instead of assembly
   - update build script accordingly

Got this running on a Linux machine with openjdk v17.0.15.